### PR TITLE
feat: Store join session data

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,3 @@
+# disable formatting in this folder
+DisableFormat: true
+SortIncludes: Never

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+* Support for storing session data and keeping the session after device reboot, dependant on STORE_JOIN_SESSION define.
+
 ## [v4.8.0] 2024-12-20
 
 This version is based on feature branch v4.5.0 of the LoRa Basics Modem.

--- a/lbm_lib/smtc_modem_api/smtc_modem_api.h
+++ b/lbm_lib/smtc_modem_api/smtc_modem_api.h
@@ -766,6 +766,29 @@ smtc_modem_return_code_t smtc_modem_get_chip_eui( uint8_t stack_id, uint8_t chip
  */
 smtc_modem_return_code_t smtc_modem_derive_keys( uint8_t stack_id );
 
+/**
+ * @brief Restore security context.
+ *
+ * If stored, the security context can be restored. User should call this function
+ * in the reset callback.
+ * If certification is enabled, the security context is automatically restored.
+ *
+ * @param[in] stack_id
+ * @return smtc_modem_return_code_t
+ */
+smtc_modem_return_code_t smtc_modem_secure_element_restore_context(uint8_t stack_id);
+
+/**
+ * @brief Store security context.
+ *
+ * Store the security context. User should call this function after a successful join.
+ * If certification is enabled, the security context is automatically stored.
+ *
+ * @param[in] stack_id
+ * @return smtc_modem_return_code_t
+ */
+smtc_modem_return_code_t smtc_modem_secure_element_store_context(uint8_t stack_id);
+
 #if defined( USE_LR11XX_CE )
 /**
  * @brief Get Fragmented DataBlockIntKey
@@ -797,6 +820,7 @@ smtc_modem_return_code_t smtc_modem_get_data_block_int_key( uint8_t stack_id,
  */
 smtc_modem_return_code_t smtc_modem_derive_and_set_data_block_int_key(
     uint8_t stack_id, const uint8_t gen_appkey[SMTC_MODEM_KEY_LENGTH] );
+
 #endif  // USE_LR11XX_CE
 /*
  * -----------------------------------------------------------------------------

--- a/lbm_lib/smtc_modem_core/lorawan_api/lorawan_api.c
+++ b/lbm_lib/smtc_modem_core/lorawan_api/lorawan_api.c
@@ -231,6 +231,12 @@ void lorawan_api_join_status_clear( uint8_t stack_id )
     lr1mac_core_join_status_clear( &lr1_mac_obj[stack_id] );
 }
 
+void lorawan_api_join_session_restore( uint8_t stack_id )
+{
+    PANIC_IF_STACK_ID_TOO_HIGH( stack_id );
+    lr1mac_core_join_session_restore( &lr1_mac_obj[stack_id] );
+}
+
 status_lorawan_t lorawan_api_dr_strategy_set( dr_strategy_t dr_strategy, uint8_t stack_id )
 {
     PANIC_IF_STACK_ID_TOO_HIGH( stack_id );

--- a/lbm_lib/smtc_modem_core/lorawan_api/lorawan_api.h
+++ b/lbm_lib/smtc_modem_core/lorawan_api/lorawan_api.h
@@ -193,6 +193,13 @@ join_status_t lorawan_api_isjoined( uint8_t stack_id );
 void lorawan_api_join_status_clear( uint8_t stack_id );
 
 /**
+ * @brief Restore join session if active, otherwise reset the join status to NOT_JOINED
+ * 
+ * @param[in] stack_id 
+ */
+void lorawan_api_join_session_restore( uint8_t stack_id );
+
+/**
  * @brief Set datarate strategy
  * @remark The current implementation support 4 different dataRate Strategy :
  *    STATIC_ADR_MODE                   for static Devices with ADR managed by the Network

--- a/lbm_lib/smtc_modem_core/lr1mac/src/lr1_stack_mac_layer.c
+++ b/lbm_lib/smtc_modem_core/lr1mac/src/lr1_stack_mac_layer.c
@@ -181,12 +181,23 @@ void lr1_stack_mac_region_init( lr1_stack_mac_t* lr1_mac, smtc_real_region_types
 void lr1_stack_mac_region_config( lr1_stack_mac_t* lr1_mac )
 {
     smtc_real_config( lr1_mac->real );
-    lr1_mac->rx2_frequency    = real_const.const_rx2_freq;
     lr1_mac->tx_power         = real_const.const_tx_power_dbm;
     lr1_mac->max_erp_dbm      = real_const.const_tx_power_dbm;
+#if defined( STORE_JOIN_SESSION )
+    // If we are keeping join session, use the stored values
+    if(lr1_mac->join_status != JOINED)
+    {	
+	lr1_mac->rx2_frequency    = real_const.const_rx2_freq;
+	lr1_mac->rx1_dr_offset    = 0;
+	lr1_mac->rx2_data_rate    = real_const.const_rx2_dr_init;
+	lr1_mac->rx1_delay_s      = real_const.const_received_delay1;
+    }
+#else 
+    lr1_mac->rx2_frequency    = real_const.const_rx2_freq;
     lr1_mac->rx1_dr_offset    = 0;
     lr1_mac->rx2_data_rate    = real_const.const_rx2_dr_init;
     lr1_mac->rx1_delay_s      = real_const.const_received_delay1;
+#endif
     lr1_mac->tx_data_rate_adr = real_const.const_min_tx_dr_limit;
 
     // If 0 the beacon of the region is used, else this freq is used even if the beacon must be hopping

--- a/lbm_lib/smtc_modem_core/lr1mac/src/lr1mac_core.c
+++ b/lbm_lib/smtc_modem_core/lr1mac/src/lr1mac_core.c
@@ -544,6 +544,24 @@ void lr1mac_core_join_status_clear( lr1_stack_mac_t* lr1_mac_obj )
     lr1_mac_obj->adr_mode_select = lr1_mac_obj->adr_mode_select_tmp;
 }
 
+void lr1mac_core_join_session_restore( lr1_stack_mac_t* lr1_mac_obj )
+{
+    // If joined, keep the session and init context
+    if(lr1_mac_obj->join_status == JOINED)
+    {
+	lr1mac_core_abort( lr1_mac_obj );
+	smtc_real_init_join_snapshot_channel_mask( lr1_mac_obj->real );
+	lr1_mac_obj->retry_join_cpt = 0;
+
+	// Revert ADR modem in case the leave network command is called before join success
+	lr1_mac_obj->adr_mode_select = lr1_mac_obj->adr_mode_select_tmp;
+	smtc_real_update_cflist( lr1_mac_obj->real, lr1_mac_obj->cf_list );
+    }
+    else {
+	lr1mac_core_join_status_clear( lr1_mac_obj );
+    }
+}
+
 /**************************************************/
 /*         LoraWan  SendPayload  Method           */
 /**************************************************/
@@ -789,15 +807,37 @@ void lr1mac_core_context_save( lr1_stack_mac_t* lr1_mac_obj )
     if( ( ctx.devnonce != lr1_mac_obj->dev_nonce ) ||
         ( memcmp( ctx.join_nonce, lr1_mac_obj->join_nonce, sizeof( ctx.join_nonce ) ) != 0 ) ||
         ( ctx.certification_enabled != lr1_mac_obj->is_lorawan_modem_certification_enabled ) ||
-        ( ctx.region != lr1_mac_obj->real->region_type ) )
+        ( ctx.region != lr1_mac_obj->real->region_type ) 
+#if defined( STORE_JOIN_SESSION )
+	|| ( memcmp( ctx.cf_list, lr1_mac_obj->cf_list, sizeof( ctx.cf_list ) ) != 0 ) ||
+	(ctx.fcnt_up != lr1_mac_obj->fcnt_up) ||
+	(ctx.fcnt_dwn != lr1_mac_obj->fcnt_dwn) ||
+	(ctx.dev_addr != lr1_mac_obj->dev_addr) || 
+	( ctx.rx2_data_rate != lr1_mac_obj->rx2_data_rate ) ||
+	( ctx.rx2_frequency != lr1_mac_obj->rx2_frequency ) ||
+	( ctx.rx1_dr_offset != lr1_mac_obj->rx1_dr_offset ) ||
+	( ctx.rx1_delay_s != lr1_mac_obj->rx1_delay_s ) || 
+	( ctx.join_status != lr1_mac_obj->join_status )
+#endif
+	)
     {
         ctx.ctx_version = LORAWAN_NVM_CTX_VERSION;
         ctx.devnonce    = lr1_mac_obj->dev_nonce;
         memcpy( ctx.join_nonce, lr1_mac_obj->join_nonce, sizeof( ctx.join_nonce ) );
         ctx.certification_enabled = lr1_mac_obj->is_lorawan_modem_certification_enabled;
         ctx.region                = lr1_mac_obj->real->region_type;
-        ctx.crc                   = lr1mac_utilities_crc( ( uint8_t* ) &ctx, sizeof( ctx ) - sizeof( ctx.crc ) );
-
+#if defined( STORE_JOIN_SESSION )
+	memcpy( ctx.cf_list, lr1_mac_obj->cf_list, sizeof( ctx.cf_list ) );
+	ctx.fcnt_up	      	  = lr1_mac_obj->fcnt_up;
+	ctx.fcnt_dwn	      	  = lr1_mac_obj->fcnt_dwn;
+	ctx.dev_addr	      	  = lr1_mac_obj->dev_addr;
+        ctx.rx2_data_rate	  = lr1_mac_obj->rx2_data_rate;
+	ctx.rx2_frequency	  = lr1_mac_obj->rx2_frequency;
+	ctx.rx1_dr_offset	  = lr1_mac_obj->rx1_dr_offset;
+	ctx.rx1_delay_s	  	  = lr1_mac_obj->rx1_delay_s;
+	ctx.join_status	  	  = lr1_mac_obj->join_status;
+	ctx.crc                   = lr1mac_utilities_crc( ( uint8_t* ) &ctx, sizeof( ctx ) - sizeof( ctx.crc ) );
+#endif	
         smtc_modem_hal_context_store( CONTEXT_LORAWAN_STACK, lr1_mac_obj->stack_id * sizeof( ctx ), ( uint8_t* ) &ctx,
                                       sizeof( ctx ) );
 
@@ -820,7 +860,17 @@ status_lorawan_t lr1mac_core_context_load( lr1_stack_mac_t* lr1_mac_obj )
         memcpy( lr1_mac_obj->join_nonce, ctx.join_nonce, sizeof( lr1_mac_obj->join_nonce ) );
         lr1_mac_obj->is_lorawan_modem_certification_enabled = ctx.certification_enabled;
         lr1_mac_obj->real->region_type                      = ctx.region;
-
+#if defined( STORE_JOIN_SESSION )
+	memcpy( lr1_mac_obj->cf_list, ctx.cf_list, sizeof( lr1_mac_obj->cf_list ) );
+	lr1_mac_obj->fcnt_up 				    = ctx.fcnt_up;
+	lr1_mac_obj->fcnt_dwn 				    = ctx.fcnt_dwn;
+	lr1_mac_obj->dev_addr 				    = ctx.dev_addr;
+	lr1_mac_obj->rx2_data_rate 			    = ctx.rx2_data_rate;
+	lr1_mac_obj->rx2_frequency 			    = ctx.rx2_frequency;
+	lr1_mac_obj->rx1_dr_offset 			    = ctx.rx1_dr_offset;
+	lr1_mac_obj->rx1_delay_s 			    = ctx.rx1_delay_s;
+	lr1_mac_obj->join_status 			    = ctx.join_status;
+#endif
         return OKLORAWAN;
     }
     else
@@ -1332,6 +1382,10 @@ static void lr1mac_mac_update( lr1_stack_mac_t* lr1_mac_obj )
         lr1_mac_obj->lr1mac_state = LWPSTATE_IDLE;
     }
     lr1_mac_obj->valid_rx_packet = NO_MORE_VALID_RX_PACKET;
+
+#if defined( STORE_JOIN_SESSION )
+	lr1mac_core_context_save(lr1_mac_obj);
+#endif
 }
 
 /* --- EOF ------------------------------------------------------------------ */

--- a/lbm_lib/smtc_modem_core/lr1mac/src/lr1mac_core.h
+++ b/lbm_lib/smtc_modem_core/lr1mac/src/lr1mac_core.h
@@ -92,6 +92,13 @@ status_lorawan_t lr1mac_core_join( lr1_stack_mac_t* lr1_mac_obj, uint32_t target
 void lr1mac_core_join_status_clear( lr1_stack_mac_t* lr1_mac_obj );
 
 /**
+ * @brief Keep join session if joined, otherwise reset the join status to NotJoined
+ * 
+ * @param[in] lr1_mac_obj 
+ */
+void lr1mac_core_join_session_restore( lr1_stack_mac_t* lr1_mac_obj );
+
+/**
  * @brief abort LoRaWAN task
  * @remark Tx, Rx will be aborted
  *

--- a/lbm_lib/smtc_modem_core/lr1mac/src/lr1mac_defs.h
+++ b/lbm_lib/smtc_modem_core/lr1mac/src/lr1mac_defs.h
@@ -489,12 +489,22 @@ typedef struct lr1mac_rx_session_param_s
 
 typedef struct lr1_mac_nvm_context_s
 {
-    uint8_t  ctx_version;
-    uint16_t devnonce;
-    uint8_t  join_nonce[6];
-    uint8_t  certification_enabled;
-    uint8_t  region;
-    uint8_t  rfu[17];  // bytes reserved for future used
+    uint8_t       ctx_version;
+    uint16_t      devnonce;
+    uint8_t       join_nonce[6];
+    uint8_t       certification_enabled;
+    uint8_t       region;
+#if defined( STORE_JOIN_SESSION )
+    uint8_t       cf_list[16];
+    uint32_t      fcnt_up;
+    uint32_t      fcnt_dwn;
+    uint32_t      dev_addr;
+    uint8_t       rx2_data_rate;
+    uint32_t      rx2_frequency;
+    uint8_t       rx1_dr_offset;
+    uint8_t       rx1_delay_s;
+    join_status_t join_status;
+#endif
     uint32_t crc;      // !! crc MUST be the last field of the structure !!
 } lr1_mac_nvm_context_t;
 

--- a/lbm_lib/smtc_modem_core/modem_utilities/modem_core.c
+++ b/lbm_lib/smtc_modem_core/modem_utilities/modem_core.c
@@ -161,7 +161,13 @@ void modem_context_init_light( void ( *callback )( void ), radio_planner_t* rp )
         lorawan_api_init( rp, stack_id, ( void ( * )( lr1_stack_mac_down_data_t* ) ) modem_downlink_callback );
 
         lorawan_api_dr_strategy_set( STATIC_ADR_MODE, stack_id );
-        lorawan_api_join_status_clear( stack_id );
+	
+#if defined ( STORE_JOIN_SESSION )
+	SMTC_MODEM_HAL_TRACE_PRINTF( "Trying to restore join session.\n" );
+	lorawan_api_join_session_restore( stack_id );
+#else
+	lorawan_api_join_status_clear( stack_id );
+#endif
 
         // to init duty cycle
         smtc_real_region_types_t region = lorawan_api_get_region( stack_id );

--- a/lbm_lib/smtc_modem_core/smtc_modem.c
+++ b/lbm_lib/smtc_modem_core/smtc_modem.c
@@ -1267,6 +1267,30 @@ smtc_modem_return_code_t smtc_modem_derive_keys( uint8_t stack_id )
     }
     return SMTC_MODEM_RC_OK;
 }
+
+smtc_modem_return_code_t smtc_modem_secure_element_restore_context(uint8_t stack_id)
+{
+	smtc_modem_return_code_t return_code = SMTC_MODEM_RC_OK;
+
+	if( smtc_secure_element_restore_context(stack_id) != SMTC_SE_RC_SUCCESS )
+	{
+		return_code = SMTC_MODEM_RC_FAIL;
+	}
+
+	return return_code;
+}
+
+smtc_modem_return_code_t smtc_modem_secure_element_store_context(uint8_t stack_id)
+{
+	smtc_modem_return_code_t return_code = SMTC_MODEM_RC_OK;
+
+	if( smtc_secure_element_store_context(stack_id) != SMTC_SE_RC_SUCCESS )
+	{
+		return_code = SMTC_MODEM_RC_FAIL;
+	}
+
+	return return_code;
+}
 #endif  // USE_LR11XX_CE
 
 /*


### PR DESCRIPTION
# Description

Add an option to store additional join session data and resume an existing join session after reboot. Minimal changes are introduced to the existing library. In particular:

* additional variables from `lr1_stack_mac_t` struct are defined for storage -> modification of the `lr1_mac_nvm_context_t` structure and `lr1mac_core_context_save()`, `lr1mac_core_context_load()` function.
* add saving of the context after each `lr1mac_mac_update()` call to save counters.
* add `lr1mac_core_join_session_restore()` function that initializes context in similar way to `lr1mac_core_join_status_clear()` without resetting join status.
* We utilise `lr11xx_ce_data_t` structure with support for saving to NVS to store EUI and AppKey, which is by default stored only if certification mode is set. To avoid this, we add `smtc_modem_secure_element_store_context()` and `smtc_modem_secure_element_restore_context()` functions that can be called on the application level.

Closes #1

## Areas of interest for the reviewer

Please check all. If you have any comments on the implementation, feel free to add in. 
I did test performance only with `lr1120` using Class A on EUR868 band. There is a possibility this does not work in other cases (definitely applicable only for lr1110 and lr1120 due to devEUI access and context storage). 

## Checklist

- [x] My code follows the [style guidelines] as defined by IRNAS.
- [x] I have performed a self-review of my code.
- [x] My changes generate no new warnings.
- [x] I added/updated source code documentation for all newly added or changed functions.
- [x] I updated all customer-facing technical documentation.

## After-review steps

- I will merge PR by myself.

[style guidelines]:
  https://github.com/IRNAS/irnas-guidelines-docs/blob/main/docs/developer_guidelines.md