### PR TITLE
feat: add access to set_nb_of_uplinks_before_reset function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Added
 
 * Support for storing session data and keeping the session after device reboot, dependant on STORE_JOIN_SESSION define.
+* Add user access to the `lorawan_api_set_no_rx_packet_threshold` function.
 
 ## [v4.8.0] 2024-12-20
 

--- a/lbm_lib/smtc_modem_api/smtc_modem_api.h
+++ b/lbm_lib/smtc_modem_api/smtc_modem_api.h
@@ -943,6 +943,19 @@ smtc_modem_return_code_t smtc_modem_get_certification_mode( uint8_t stack_id, bo
 smtc_modem_return_code_t smtc_modem_set_certification_mode( uint8_t stack_id, bool enable );
 
 /**
+ * @brief Set the number of uplinks before reset
+ *
+ * @param [in]  stack_id            Stack identifier
+ * @param [out] nb_of_uplinks       Number of uplinks before reset
+ *
+ * @return Modem return code as defined in @ref smtc_modem_return_code_t
+ * @retval SMTC_MODEM_RC_OK                Command executed without errors
+ * @retval SMTC_MODEM_RC_BUSY              Modem is currently in test mode
+ * @retval SMTC_MODEM_RC_INVALID_STACK_ID  Invalid \p stack_id
+ */
+smtc_modem_return_code_t smtc_modem_set_nb_of_uplinks_before_reset( uint8_t stack_id, uint8_t nb_of_uplinks_before_reset );
+
+/**
  * @brief Request an immediate LoRaWAN uplink
  *
  * @remark It has higher priority than all other services and is not subject to duty cycle restrictions, if any

--- a/lbm_lib/smtc_modem_core/smtc_modem.c
+++ b/lbm_lib/smtc_modem_core/smtc_modem.c
@@ -1024,6 +1024,21 @@ smtc_modem_return_code_t smtc_modem_set_certification_mode( uint8_t stack_id, bo
     return SMTC_MODEM_RC_OK;
 }
 
+smtc_modem_return_code_t smtc_modem_set_nb_of_uplinks_before_reset( uint8_t stack_id, uint8_t nb_of_uplinks_before_reset )
+{
+	    RETURN_BUSY_IF_TEST_MODE( );
+
+    if( nb_of_uplinks_before_reset > 0 )
+    {
+	lorawan_api_set_no_rx_packet_threshold( nb_of_uplinks_before_reset , stack_id);
+    }
+    else
+    {
+	lorawan_api_set_no_rx_packet_threshold( 0 , stack_id);
+    }
+    return SMTC_MODEM_RC_OK;
+}
+
 smtc_modem_return_code_t smtc_modem_request_emergency_uplink( uint8_t stack_id, uint8_t fport, bool confirmed,
                                                               const uint8_t* payload, uint8_t payload_length )
 {


### PR DESCRIPTION
The `smtc_modem_connection_timeout_set_thresholds()`, function was removed from the `modem_api`. It has called two functions:

- `modem_set_adr_mobile_timeout_config( nb_of_uplinks_before_network_controlled )` - this functionality is no longer supported by the driver,
- `lorawan_api_set_no_rx_packet_threshold(nb_of_uplinks_before_reset, STACK_ID)` - exists but is not directly accessible.

Wrapper function was added to  `smtc_modem_api` to make `lorawan_api_set_no_rx_packet_threshold` accessible.