### PR TITLE
feat: Add user access to beacon data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 * Support for storing session data and keeping the session after device reboot, dependant on STORE_JOIN_SESSION define.
 * Add user access to the `lorawan_api_set_no_rx_packet_threshold` function.
+* Add user access to the beacon statistics data with `smtc_modem_class_b_beacon_get_statistics` function.
 
 ## [v4.8.0] 2024-12-20
 

--- a/lbm_lib/smtc_modem_api/smtc_modem_api.h
+++ b/lbm_lib/smtc_modem_api/smtc_modem_api.h
@@ -245,6 +245,19 @@ typedef struct smtc_modem_dl_metadata_s
     uint8_t                datarate;
 } smtc_modem_dl_metadata_t;
 
+typedef enum smtc_modem_beacon_state_e
+{
+    SMTC_BEACON_UNLOCK,
+    SMTC_BEACON_LOCK,
+} smtc_modem_beacon_state_t;
+typedef struct smtc_modem_beacon_statistics_s
+{
+    smtc_modem_beacon_state_t beacon_state;        //!< the state of the beacon state machine
+    uint32_t nb_beacon_received;              //!< Number of beacons received
+    uint32_t nb_beacon_missed;                //!< Number of beacons missed
+    uint32_t last_beacon_received_timestamp;      //!< Last beacon received timestamp in ms
+} smtc_modem_beacon_statistics_t;
+
 /**
  * @brief Cipher mode for stream service
  */
@@ -1516,6 +1529,19 @@ smtc_modem_return_code_t smtc_modem_class_b_set_ping_slot_periodicity(
 smtc_modem_return_code_t smtc_modem_class_b_get_ping_slot_periodicity(
     uint8_t stack_id, smtc_modem_class_b_ping_slot_periodicity_t* ping_slot_periodicity );
 
+
+/**
+ * @brief Get last valid beacon timestamp
+ *
+ * @param[in] stack_id Stack identifier
+ * @param[out] beacon_statistics beacon statistics structure to be filled
+ * @return Modem return code as defined in @ref smtc_modem_return_code_t
+ * @retval SMTC_MODEM_RC_OK                 Command executed without errors
+ * @retval SMTC_MODEM_RC_BUSY               Modem is currently in test mode
+ * @retval SMTC_MODEM_RC_INVALID_STACK_ID   Invalid \p stack_id
+ */
+smtc_modem_return_code_t smtc_modem_class_b_beacon_get_statistics(smtc_modem_beacon_statistics_t *beacon_statistics,
+								  uint8_t stack_id );
 /**
  * @brief Configure a multicast group
  *

--- a/lbm_lib/smtc_modem_core/smtc_modem.c
+++ b/lbm_lib/smtc_modem_core/smtc_modem.c
@@ -1784,6 +1784,22 @@ smtc_modem_return_code_t smtc_modem_class_b_get_ping_slot_periodicity(
     return SMTC_MODEM_RC_OK;
 }
 
+smtc_modem_return_code_t smtc_modem_class_b_beacon_get_statistics(smtc_modem_beacon_statistics_t *beacon_statistics,
+								  uint8_t stack_id )
+{
+    RETURN_BUSY_IF_TEST_MODE( );
+
+    smtc_beacon_statistics_t statistics;
+    lorawan_api_beacon_get_statistics(&statistics, stack_id);
+
+    beacon_statistics->beacon_state = (smtc_modem_beacon_state_t) statistics.beacon_state;
+    beacon_statistics->nb_beacon_received = statistics.nb_beacon_received;
+    beacon_statistics->nb_beacon_missed = statistics.nb_beacon_missed;
+    beacon_statistics->last_beacon_received_timestamp = statistics.last_beacon_received_timestamp;
+
+    return SMTC_MODEM_RC_OK;
+}
+
 smtc_modem_return_code_t smtc_modem_multicast_set_grp_config( uint8_t stack_id, smtc_modem_mc_grp_id_t mc_grp_id,
                                                               uint32_t      mc_grp_addr,
                                                               const uint8_t mc_nwk_skey[SMTC_MODEM_KEY_LENGTH],


### PR DESCRIPTION
Add user access to the `smtc_beacon_statistics_t` data structure by adding `smtc_modem_class_b_beacon_get_statistics()` interface function.