### PR TITLE
fix: fix bug in smtc_modem_class_b_beacon_get_statistics function

### DIFF
--- a/lbm_lib/smtc_modem_api/smtc_modem_api.h
+++ b/lbm_lib/smtc_modem_api/smtc_modem_api.h
@@ -1537,6 +1537,7 @@ smtc_modem_return_code_t smtc_modem_class_b_get_ping_slot_periodicity(
  * @param[out] beacon_statistics beacon statistics structure to be filled
  * @return Modem return code as defined in @ref smtc_modem_return_code_t
  * @retval SMTC_MODEM_RC_OK                 Command executed without errors
+ * @retval SMTC_MODEM_RC_INVALID           Class B not supported
  * @retval SMTC_MODEM_RC_BUSY               Modem is currently in test mode
  * @retval SMTC_MODEM_RC_INVALID_STACK_ID   Invalid \p stack_id
  */

--- a/lbm_lib/smtc_modem_core/smtc_modem.c
+++ b/lbm_lib/smtc_modem_core/smtc_modem.c
@@ -1789,6 +1789,7 @@ smtc_modem_return_code_t smtc_modem_class_b_beacon_get_statistics(smtc_modem_bea
 {
     RETURN_BUSY_IF_TEST_MODE( );
 
+#if defined( ADD_CLASS_B )
     smtc_beacon_statistics_t statistics;
     lorawan_api_beacon_get_statistics(&statistics, stack_id);
 
@@ -1796,7 +1797,9 @@ smtc_modem_return_code_t smtc_modem_class_b_beacon_get_statistics(smtc_modem_bea
     beacon_statistics->nb_beacon_received = statistics.nb_beacon_received;
     beacon_statistics->nb_beacon_missed = statistics.nb_beacon_missed;
     beacon_statistics->last_beacon_received_timestamp = statistics.last_beacon_received_timestamp;
-
+#else
+	return SMTC_MODEM_RC_INVALID;
+#endif  // ADD_CLASS_B
     return SMTC_MODEM_RC_OK;
 }
 


### PR DESCRIPTION
Fix bug in the `smtc_modem_class_b_beacon_get_statistics` - when the class B config was not set, we got an error.