### PR TITLE
feat: add factory reset function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * Support for storing session data and keeping the session after device reboot, dependant on STORE_JOIN_SESSION define.
 * Add user access to the `lorawan_api_set_no_rx_packet_threshold` function.
 * Add user access to the beacon statistics data with `smtc_modem_class_b_beacon_get_statistics` function.
+* Add user access to the `smtc_modem_factory_reset` function.
 
 ## [v4.8.0] 2024-12-20
 

--- a/lbm_lib/smtc_modem_api/smtc_modem_api.h
+++ b/lbm_lib/smtc_modem_api/smtc_modem_api.h
@@ -1023,6 +1023,18 @@ smtc_modem_return_code_t smtc_modem_request_empty_uplink( uint8_t stack_id, bool
 smtc_modem_return_code_t smtc_modem_leave_network( uint8_t stack_id );
 
 /**
+ * @brief Cancel on ongoing processes and factory reset the modem
+ *
+ * @param [in] stack_id Stack identifier
+ *
+ * @return Modem return code as defined in @ref smtc_modem_return_code_t
+ * @retval SMTC_MODEM_RC_OK                Command executed without errors
+ * @retval SMTC_MODEM_RC_BUSY              Modem is currently in test mode
+ * @retval SMTC_MODEM_RC_INVALID_STACK_ID  Invalid \p stack_id
+ */
+smtc_modem_return_code_t smtc_modem_factory_reset( uint8_t stack_id );
+
+/**
  * @brief Get the radio communications suspend status
  *
  * @param [in] stack_id     Stack identifier

--- a/lbm_lib/smtc_modem_core/modem_utilities/modem_core.c
+++ b/lbm_lib/smtc_modem_core/modem_utilities/modem_core.c
@@ -227,6 +227,8 @@ void modem_context_init_light( void ( *callback )( void ), radio_planner_t* rp )
     modem_load_modem_context( );
     // Increment reset counter
     modem_reset_counter++;
+    // Save modem context - to keep the reset counter
+    modem_store_modem_context( );
 }
 
 fifo_ctrl_t* modem_context_get_fifo_obj( void )

--- a/lbm_lib/smtc_modem_core/smtc_modem.c
+++ b/lbm_lib/smtc_modem_core/smtc_modem.c
@@ -1104,6 +1104,23 @@ smtc_modem_return_code_t smtc_modem_leave_network( uint8_t stack_id )
     return return_code;
 }
 
+smtc_modem_return_code_t smtc_modem_factory_reset( uint8_t stack_id )
+{
+    smtc_modem_return_code_t return_code = SMTC_MODEM_RC_OK;
+    RETURN_BUSY_IF_TEST_MODE( );
+
+    // Stop processes
+    smtc_modem_set_class( stack_id, SMTC_MODEM_CLASS_A );
+    tx_protocol_manager_abort( );
+    modem_supervisor_abort_tasks_in_range( stack_id * NUMBER_OF_TASKS, ( ( stack_id + 1 ) * NUMBER_OF_TASKS ) - 1 );
+    lorawan_api_join_status_clear( stack_id );
+
+    // Reset all modem parameters to factory defaults
+    lorawan_api_factory_reset( stack_id );
+
+    return return_code;
+}
+
 smtc_modem_return_code_t smtc_modem_get_suspend_radio_communications( uint8_t stack_id, bool* suspend )
 {
     *suspend = modem_supervisor_get_modem_is_suspended( stack_id );


### PR DESCRIPTION
Add `smtc_modem_factory_reset` function that cancels ongoing processes and factory resets the modem.

Also, add a call `modem_store_modem_context( )` function at the end of modem init to store reset counter - in the case of restoring join session (not going through join process), the stored counter was not updated. 