### PR TITLE
fix: Add fix for setting 2.4 ghz frequency to multicast group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * Add user access to the `lorawan_api_set_no_rx_packet_threshold` function.
 * Add user access to the beacon statistics data with `smtc_modem_class_b_beacon_get_statistics` function.
 * Add user access to the `smtc_modem_factory_reset` function.
+* Add support for 2.4 Ghz multicast class C session frequency setting.
 
 ## [v4.8.0] 2024-12-20
 

--- a/lbm_lib/smtc_modem_core/lorawan_packages/remote_multicast_setup/v1.0.0/lorawan_remote_multicast_setup_package_v1.0.0.c
+++ b/lbm_lib/smtc_modem_core/lorawan_packages/remote_multicast_setup/v1.0.0/lorawan_remote_multicast_setup_package_v1.0.0.c
@@ -998,7 +998,14 @@ static remote_multicast_setup_status_t remote_multicast_setup_package_parser(
                 multicast_group_params[mc_grp_id].params.frequency = rx_buffer[rx_buffer_index + 7] +
                                                                      ( rx_buffer[rx_buffer_index + 8] << 8 ) +
                                                                      ( rx_buffer[rx_buffer_index + 9] << 16 );
-                multicast_group_params[mc_grp_id].params.frequency *= 100;
+                // Note: Workaround for using FUOTA with 2.4Ghz
+		// There are only 3 bytes for frequency in the multicast setup command, which doesn't fit 2.4 ghz, so received frequency is divided by 2
+		// In the case of SMTC_REAL_REGION_WW2G4 multiply by 2
+		if( lorawan_api_get_region( stack_id ) == SMTC_REAL_REGION_WW2G4 )
+		{
+			multicast_group_params[mc_grp_id].params.frequency *= 2;
+		}
+		multicast_group_params[mc_grp_id].params.frequency *= 100;
                 multicast_group_params[mc_grp_id].params.dr = rx_buffer[rx_buffer_index + 10] & 0x0F;
                 SMTC_MODEM_HAL_TRACE_PRINTF(
                     "multicast_group_params %d ;%d ;%d ;%d \n", multicast_group_params[mc_grp_id].params.session_time,

--- a/lbm_lib/smtc_modem_core/lorawan_packages/remote_multicast_setup/v2.0.0/lorawan_remote_multicast_setup_package_v2.0.0.c
+++ b/lbm_lib/smtc_modem_core/lorawan_packages/remote_multicast_setup/v2.0.0/lorawan_remote_multicast_setup_package_v2.0.0.c
@@ -998,7 +998,15 @@ static remote_multicast_setup_status_t remote_multicast_setup_package_parser(
                 multicast_group_params[mc_grp_id].params.frequency = rx_buffer[rx_buffer_index + 7] +
                                                                      ( rx_buffer[rx_buffer_index + 8] << 8 ) +
                                                                      ( rx_buffer[rx_buffer_index + 9] << 16 );
-                multicast_group_params[mc_grp_id].params.frequency *= 100;
+
+		// Note: Workaround for using FUOTA with 2.4Ghz
+		// There are only 3 bytes for frequency in the multicast setup command, which doesn't fit 2.4 ghz, so received frequency is divided by 2
+		// In the case of SMTC_REAL_REGION_WW2G4 multiply by 2
+		if( lorawan_api_get_region( stack_id ) == SMTC_REAL_REGION_WW2G4 )
+		{
+			multicast_group_params[mc_grp_id].params.frequency *= 2;
+		}
+		multicast_group_params[mc_grp_id].params.frequency *= 100;
                 multicast_group_params[mc_grp_id].params.dr = rx_buffer[rx_buffer_index + 10] & 0x0F;
                 SMTC_MODEM_HAL_TRACE_PRINTF(
                     "multicast_group_params %d ;%d ;%d ;%d \n", multicast_group_params[mc_grp_id].params.session_time,


### PR DESCRIPTION
Add support for setting a multicast class C group with 2.4 GHz band.

MAC command `McClassCSessionReq` has only 3 bytes available for setting frequency in format `freq_in_hz/100`. We implement a workaround where in the case of a 2.4GHz device, we multiply the frequency by 2, as only the high byte is missing.