### PR TITLE
feat: add external front-end module support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * Add user access to the beacon statistics data with `smtc_modem_class_b_beacon_get_statistics` function.
 * Add user access to the `smtc_modem_factory_reset` function.
 * Add multi-radio support. NOTE: not fully tested. Samples are not updated or tested.
+* Add external front-end module support for SX128X.
 
 ## [v4.9.0] 2025-10-15
 

--- a/lbm_lib/smtc_modem_core/smtc_ral/src/ral_sx128x.c
+++ b/lbm_lib/smtc_modem_core/smtc_ral/src/ral_sx128x.c
@@ -225,7 +225,11 @@ ral_status_t ral_sx128x_set_sleep( const void* context, const bool retain_config
         }
     }
 
-    return ( ral_status_t ) sx128x_set_sleep( context, false, retain_config );
+    ral_status_t ret = ( ral_status_t ) sx128x_set_sleep( context, false, retain_config );
+
+    ral_sx128x_bsp_set_front_end_off( context );
+
+    return ret;
 }
 
 ral_status_t ral_sx128x_set_standby( const void* context, ral_standby_cfg_t standby_cfg )
@@ -248,7 +252,11 @@ ral_status_t ral_sx128x_set_standby( const void* context, ral_standby_cfg_t stan
         return RAL_STATUS_UNKNOWN_VALUE;
     }
 
-    return ( ral_status_t ) sx128x_set_standby( context, radio_standby_cfg );
+    ral_status_t ret = ( ral_status_t ) sx128x_set_standby( context, radio_standby_cfg );
+
+    ral_sx128x_bsp_set_front_end_off( context );
+
+    return ret;
 }
 
 ral_status_t ral_sx128x_set_fs( const void* context )
@@ -258,11 +266,14 @@ ral_status_t ral_sx128x_set_fs( const void* context )
 
 ral_status_t ral_sx128x_set_tx( const void* context )
 {
+    ral_sx128x_bsp_set_front_end_tx( context );
     return ( ral_status_t ) sx128x_set_tx( context, SX128X_TICK_SIZE_1000_US, 0 );
 }
 
 ral_status_t ral_sx128x_set_rx( const void* context, const uint32_t timeout_in_ms )
 {
+    ral_sx128x_bsp_set_front_end_rx( context );
+
     if( timeout_in_ms == RAL_RX_TIMEOUT_CONTINUOUS_MODE )
     {
         return ( ral_status_t ) sx128x_set_rx( context, SX128X_TICK_SIZE_1000_US, 0xFFFF );
@@ -292,6 +303,7 @@ ral_status_t ral_sx128x_cfg_rx_boosted( const void* context, const bool enable_b
 ral_status_t ral_sx128x_set_rx_tx_fallback_mode( const void* context, const ral_fallback_modes_t ral_fallback_mode )
 {
     bool fallback_mode_is_fs;
+    /* EvaTODO: what to do with front-end module? */
 
     switch( ral_fallback_mode )
     {
@@ -345,11 +357,15 @@ ral_status_t ral_sx128x_set_lora_cad( const void* context )
 
 ral_status_t ral_sx128x_set_tx_cw( const void* context )
 {
+    ral_sx128x_bsp_set_front_end_tx( context );
+
     return ( ral_status_t ) sx128x_set_tx_cw( context );
 }
 
 ral_status_t ral_sx128x_set_tx_infinite_preamble( const void* context )
 {
+    ral_sx128x_bsp_set_front_end_tx( context );
+
     return ( ral_status_t ) sx128x_set_tx_infinite_preamble( context );
 }
 

--- a/lbm_lib/smtc_modem_core/smtc_ral/src/ral_sx128x_bsp.h
+++ b/lbm_lib/smtc_modem_core/smtc_ral/src/ral_sx128x_bsp.h
@@ -150,6 +150,35 @@ ral_status_t ral_sx128x_bsp_get_instantaneous_gfsk_rx_power_consumption( const v
 ral_status_t ral_sx128x_bsp_get_instantaneous_lora_rx_power_consumption( const void* context,
     sx128x_reg_mod_t reg_mode, ral_lora_bw_t bw, bool rx_boosted, uint32_t* pwr_consumption_in_ua );
 
+
+/**
+ * @brief Set external front end module for transmission, if defined.
+ *
+ * @param[in] context Chip implementation context
+ */
+void ral_sx128x_bsp_set_front_end_tx(const void* context);
+
+/**
+ * @brief Set external front end module for reception, if defined.
+ *
+ * @param[in] context Chip implementation context
+ */
+void ral_sx128x_bsp_set_front_end_rx(const void* context);
+
+/**
+ * @brief Set bypass for external front end module, if defined.
+ *
+ * @param[in] context Chip implementation context
+ */
+void ral_sx128x_bsp_set_front_end_bypass(const void* context);
+
+/**
+ * @brief Set external front end module off, if defined.
+ *
+ * @param[in] context Chip implementation context
+ */
+void ral_sx128x_bsp_set_front_end_off(const void* context);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
Add option to have external front-end module support for SX128X radio. 

Note: Same support can be implemented for other radio types.  Issue: #15 