### PR TITLE
Feat/fix beacon drop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * Add external front-end module support for SX128X.
 * Fix number of services in callback implementation.
 * Fix number of stacks in FUOTA support packages.
+* Add class B beacon power setting config.
+* Expose function that converts RTC time to GPS epoch time.
 
 ## [v4.9.0] 2025-10-15
 

--- a/lbm_lib/smtc_modem_api/smtc_modem_api.h
+++ b/lbm_lib/smtc_modem_api/smtc_modem_api.h
@@ -1875,6 +1875,22 @@ smtc_modem_return_code_t smtc_modem_get_lorawan_mac_time( uint8_t stack_id, uint
                                                           uint32_t* gps_fractional_s );
 
 /**
+ * @brief Convert RTC time to GPS epoch time
+ *
+ * @param[in] stack_id Stack identifier
+ * @param[in] rtc_time RTC time in milliseconds
+ * @param[out] gps_time_s GPS time in seconds
+ * @param[out] gps_fractional_s GPS fractional second
+ * @return Modem return code as defined in @ref smtc_modem_return_code_t
+ * @retval SMTC_MODEM_RC_OK            Command executed without errors
+ * @retval SMTC_MODEM_RC_INVALID       \p gps_time_s or \p gps_fractional_s are NULL
+ * @retval SMTC_MODEM_RC_BUSY          Modem is currently in test mode
+ * @retval SMTC_MODEM_RC_FAIL          Conversion failed
+ */
+smtc_modem_return_code_t smtc_modem_convert_rtc_to_gps_epoch_time( uint8_t stack_id,
+	uint32_t rtc_time, uint32_t* gps_time_s, uint32_t* gps_fractional_s );
+
+/**
  * @brief Get the link check data after a successful link_check request
  *
  * @remark The demodulation margin indicates the link margin in dB of the most recently transmitted LinkCheckReq

--- a/lbm_lib/smtc_modem_core/lorawan_packages/fragmented_data_block_transport/v2.0.0/lorawan_fragmentation_package_v2.0.0.c
+++ b/lbm_lib/smtc_modem_core/lorawan_packages/fragmented_data_block_transport/v2.0.0/lorawan_fragmentation_package_v2.0.0.c
@@ -337,8 +337,6 @@ void lorawan_fragmentation_package_service_on_update( void* service_id )
     }
 }
 
-static int prv_count = 0;
-
 uint8_t lorawan_fragmentation_package_service_downlink_handler( lr1_stack_mac_down_data_t* rx_down_data )
 {
     uint8_t stack_id = rx_down_data->stack_id;

--- a/lbm_lib/smtc_modem_core/lr1mac/src/lr1mac_class_b/smtc_beacon_sniff.c
+++ b/lbm_lib/smtc_modem_core/lr1mac/src/lr1mac_class_b/smtc_beacon_sniff.c
@@ -582,6 +582,10 @@ static uint8_t get_beacon_length( uint8_t beacon_sf )
 }
 static rp_task_types_t get_beacon_rp_task_type( smtc_lr1_beacon_t* lr1_beacon_obj )
 {
+#ifdef BEACON_DISABLE_POWER_SAVING
+    SMTC_MODEM_HAL_TRACE_WARNING( "BEACON_DISABLE_POWER_SAVING is activated, the device will listen all the beacon and can't save power. Set rate: %d\n", lr1_beacon_obj->listen_beacon_rate );
+    return RP_TASK_TYPE_RX_LORA;
+#else
     if( ( ( ( lr1_beacon_obj->beacon_statistics.nb_beacon_missed +
               lr1_beacon_obj->beacon_statistics.nb_beacon_received ) %
             ( lr1_beacon_obj->listen_beacon_rate - lr1_beacon_obj->lr1_mac->stack_id ) ) == 0 ) ||
@@ -595,6 +599,7 @@ static rp_task_types_t get_beacon_rp_task_type( smtc_lr1_beacon_t* lr1_beacon_ob
     {
         return RP_TASK_TYPE_NONE;
     }
+#endif // BEACON_DISABLE_POWER_SAVING
 }
 
 static void compute_beacon_metadata( smtc_lr1_beacon_t* lr1_beacon_obj, uint32_t timestamp, uint32_t beacon_epoch_time )

--- a/lbm_lib/smtc_modem_core/smtc_modem.c
+++ b/lbm_lib/smtc_modem_core/smtc_modem.c
@@ -1810,6 +1810,16 @@ smtc_modem_return_code_t smtc_modem_get_lorawan_mac_time( uint8_t stack_id, uint
     return SMTC_MODEM_RC_OK;
 }
 
+smtc_modem_return_code_t smtc_modem_convert_rtc_to_gps_epoch_time( uint8_t stack_id, uint32_t rtc_time, uint32_t* gps_time_s, uint32_t* gps_fractional_s )
+{
+    RETURN_BUSY_IF_TEST_MODE( );
+    RETURN_INVALID_IF_NULL( gps_time_s );
+    RETURN_INVALID_IF_NULL( gps_fractional_s );
+
+    lorawan_api_convert_rtc_to_gps_epoch_time( rtc_time, gps_time_s, gps_fractional_s, stack_id );
+    return SMTC_MODEM_RC_OK;
+}
+
 smtc_modem_return_code_t smtc_modem_get_lorawan_link_check_data( uint8_t stack_id, uint8_t* margin, uint8_t* gw_cnt )
 {
     RETURN_BUSY_IF_TEST_MODE( );


### PR DESCRIPTION
**Changes**

1. Add additionl setting that disables functionality that drops beacons when having multiple stacks. 
2. Expose a function that converts RTC to GPS timestamp, so we can get beacon time out of SMTC lib.