### PR TITLE
feat: Remove set baypass mode option

### DIFF
--- a/lbm_lib/smtc_modem_core/smtc_ral/src/ral_sx128x_bsp.h
+++ b/lbm_lib/smtc_modem_core/smtc_ral/src/ral_sx128x_bsp.h
@@ -166,13 +166,6 @@ void ral_sx128x_bsp_set_front_end_tx(const void* context);
 void ral_sx128x_bsp_set_front_end_rx(const void* context);
 
 /**
- * @brief Set bypass for external front end module, if defined.
- *
- * @param[in] context Chip implementation context
- */
-void ral_sx128x_bsp_set_front_end_bypass(const void* context);
-
-/**
  * @brief Set external front end module off, if defined.
  *
  * @param[in] context Chip implementation context


### PR DESCRIPTION
Remove `void ral_sx128x_bsp_set_front_end_bypass(const void* context)` function, as it is not used by the lib. Baypass mode will be set in the `void ral_sx128x_bsp_set_front_end_tx(const void* context)`, based on the provided power setting.