### PR TITLE
feat: Add beacon epoch time to info structure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * Fix number of stacks in FUOTA support packages.
 * Add class B beacon power setting config.
 * Expose function that converts RTC time to GPS epoch time.
+* Add beacon epoch time to `smtc_modem_beacon_statistics_t` structure.
 
 ## [v4.9.0] 2025-10-15
 

--- a/lbm_lib/smtc_modem_api/smtc_modem_api.h
+++ b/lbm_lib/smtc_modem_api/smtc_modem_api.h
@@ -256,6 +256,7 @@ typedef struct smtc_modem_beacon_statistics_s
     uint32_t nb_beacon_received;              //!< Number of beacons received
     uint32_t nb_beacon_missed;                //!< Number of beacons missed
     uint32_t last_beacon_received_timestamp;      //!< Last beacon received timestamp in ms
+    uint32_t last_beacon_epoch_time;                  //!< the epoch time inside the last valid beacon
 } smtc_modem_beacon_statistics_t;
 
 /**

--- a/lbm_lib/smtc_modem_core/lr1mac/src/lr1mac_class_b/smtc_beacon_sniff.c
+++ b/lbm_lib/smtc_modem_core/lr1mac/src/lr1mac_class_b/smtc_beacon_sniff.c
@@ -313,6 +313,8 @@ smtc_class_b_beacon_t smtc_beacon_sniff_start( smtc_lr1_beacon_t* lr1_beacon_obj
                                                &fractional_second );
     // store the target gps epoch time (format gps epoch time) to lr1_beacon_obj->beacon_epoch_time
     lr1_beacon_obj->beacon_epoch_time = seconds_since_epoch;
+    // Copy to info beacon for debug and callback
+    lr1_beacon_obj->beacon_statistics.beacon_epoch_time = seconds_since_epoch;
     SMTC_MODEM_HAL_TRACE_PRINTF( "seconds_since_epoch %u, fractional_second %u ms\n", seconds_since_epoch,
                                  fractional_second );
     // launch beacon radio sniff
@@ -428,6 +430,7 @@ void smtc_beacon_sniff_rp_callback( smtc_lr1_beacon_t* lr1_beacon_obj )
         lr1_beacon_obj->is_valid_beacon = is_valid_beacon( lr1_beacon_obj, timestamp );
         lr1_beacon_obj->beacon_buffer_length =
             ( uint8_t ) lr1_beacon_obj->rp->rx_payload_size[lr1_beacon_obj->beacon_sniff_id_rp];
+	SMTC_MODEM_HAL_TRACE_PRINTF( " beacon_epoch_time = %u ms\n", beacon_epoch_time );
     }
 
     update_beacon_pll( lr1_beacon_obj, timestamp );
@@ -642,6 +645,7 @@ static void compute_beacon_metadata( smtc_lr1_beacon_t* lr1_beacon_obj, uint32_t
         lr1_beacon_obj->beacon_statistics.last_beacon_lost_consecutively = 0;
         lr1_beacon_obj->beacon_statistics.four_last_beacon_rx_statistic =
             MIN( lr1_beacon_obj->beacon_statistics.four_last_beacon_rx_statistic + 1, 4 );
+	lr1_beacon_obj->beacon_statistics.beacon_epoch_time = beacon_epoch_time;
     }
     else
     {
@@ -792,7 +796,7 @@ static bool is_valid_beacon( smtc_lr1_beacon_t* lr1_beacon_obj, uint32_t timesta
     if( status == true )
     {
         int32_t check_time = ( beacon_epoch_time - seconds_since_epoch ) * 1000 - fractional_second;
-        SMTC_MODEM_HAL_TRACE_PRINTF_DEBUG( " beacon_time - network time = %u ms\n", check_time );
+        SMTC_MODEM_HAL_TRACE_PRINTF_DEBUG( " beacon_time: %d - network time: %d fractional s: %d = %d ms\n", beacon_epoch_time, seconds_since_epoch, fractional_second, check_time );
         if( ( uint32_t ) ABS( check_time ) < MAX_BEACON_WINDOW_MS )
         {
             return true;

--- a/lbm_lib/smtc_modem_core/lr1mac/src/lr1mac_class_b/smtc_beacon_sniff.h
+++ b/lbm_lib/smtc_modem_core/lr1mac/src/lr1mac_class_b/smtc_beacon_sniff.h
@@ -165,6 +165,7 @@ typedef struct smtc_beacon_statistics_s
                                               //!< time based (in ms)
     uint8_t
         four_last_beacon_rx_statistic;  //!< return the numbers of valid received beacon during the 4 last period beacon
+    uint32_t beacon_epoch_time;         //!< the epoch time inside the last valid beacon
 } smtc_beacon_statistics_t;
 
 /**

--- a/lbm_lib/smtc_modem_core/smtc_modem.c
+++ b/lbm_lib/smtc_modem_core/smtc_modem.c
@@ -1961,6 +1961,7 @@ smtc_modem_return_code_t smtc_modem_class_b_beacon_get_statistics(smtc_modem_bea
     beacon_statistics->nb_beacon_received = statistics.nb_beacon_received;
     beacon_statistics->nb_beacon_missed = statistics.nb_beacon_missed;
     beacon_statistics->last_beacon_received_timestamp = statistics.last_beacon_received_timestamp;
+    beacon_statistics->last_beacon_epoch_time = statistics.beacon_epoch_time;
 #else
 	return SMTC_MODEM_RC_INVALID;
 #endif  // ADD_CLASS_B


### PR DESCRIPTION
Add beacon epoch time to the `smtc_modem_beacon_statistics_t` structure.

We have trouble consistently converting the provided `last_beacon_received_timestamp` (rtc time) to beacon time, the field is included directly to store the calculated value by the modem lib.