### PR TITLE
Restore channel mask after region init on session restore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * Starting join bank can be set over SMTC modem API for regions that support this (AU915, US915)
 * Subsequent join attempts cycle through all banks for regions that support this (AU915, US915)
 
+### Fixed
+* Fixed session channel mask restoration by restoring the LoRaWAN session after region initialization.
+
 ## [v4.8.0] 2024-12-20
 
 This version is based on feature branch v4.5.0 of the LoRa Basics Modem.

--- a/lbm_lib/smtc_modem_core/modem_utilities/modem_core.c
+++ b/lbm_lib/smtc_modem_core/modem_utilities/modem_core.c
@@ -161,17 +161,17 @@ void modem_context_init_light( void ( *callback )( void ), radio_planner_t* rp )
         lorawan_api_init( rp, stack_id, ( void ( * )( lr1_stack_mac_down_data_t* ) ) modem_downlink_callback );
 
         lorawan_api_dr_strategy_set( STATIC_ADR_MODE, stack_id );
-	
-#if defined ( STORE_JOIN_SESSION )
-	SMTC_MODEM_HAL_TRACE_PRINTF( "Trying to restore join session.\n" );
-	lorawan_api_join_session_restore( stack_id );
-#else
-	lorawan_api_join_status_clear( stack_id );
-#endif
 
         // to init duty cycle
         smtc_real_region_types_t region = lorawan_api_get_region( stack_id );
         lorawan_api_set_region( region, stack_id );
+
+#if defined ( STORE_JOIN_SESSION )
+	    SMTC_MODEM_HAL_TRACE_PRINTF( "Trying to restore join session.\n" );
+	    lorawan_api_join_session_restore( stack_id );
+#else
+	    lorawan_api_join_status_clear( stack_id );
+#endif
     }
 
     uint8_t index_tmp = 0;


### PR DESCRIPTION
### Fixed
* Fixed session channel mask restoration by restoring the LoRaWAN session after region initialization.

## Details

The library does save the correct channel mask received from TTN in the `JoinAccept` message (`cf_list`) and attempts to restore it on startup, however `lorawan_api_set_region` is called after `lorawan_api_join_session_restore` and resets all channel masks back to defaults overwriting the restored configuration.
Swapping the call order in `modem_context_init_light` so `lorawan_api_join_session_restore` is called after `lorawan_api_set_region` fixes this. It makes sure the stored channel mask is used after reset on first transmission.