### PR TITLE
Save session state to NVM after leaving network

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Fixed
 * Fixed session channel mask restoration by restoring the LoRaWAN session after region initialization.
+* Save session not joined state to NVM after leaving network.
 
 ## [v4.8.0] 2024-12-20
 

--- a/lbm_lib/smtc_modem_core/lr1mac/src/lr1mac_core.c
+++ b/lbm_lib/smtc_modem_core/lr1mac/src/lr1mac_core.c
@@ -542,6 +542,9 @@ void lr1mac_core_join_status_clear( lr1_stack_mac_t* lr1_mac_obj )
 
     // Revert ADR modem in case the leave network command is called before join success
     lr1_mac_obj->adr_mode_select = lr1_mac_obj->adr_mode_select_tmp;
+
+    // Persist NOT_JOINED session state so it is not restored after reset
+    lr1mac_core_context_save( lr1_mac_obj );
 }
 
 void lr1mac_core_join_session_restore( lr1_stack_mac_t* lr1_mac_obj )


### PR DESCRIPTION
### Fixed
* Save session not joined state to NVM after leaving network.